### PR TITLE
Fix logger name and remove unused import

### DIFF
--- a/src/core/merge.py
+++ b/src/core/merge.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Optional, Any
 try:
     # Import the specific types needed for clarity
     from pyannote.core import Segment as PyannoteSegment, Annotation
-    from faster_whisper.transcribe import Segment as WhisperSegmentObject, Word as WhisperWordObject
+    from faster_whisper.transcribe import Segment as WhisperSegmentObject
 except ImportError as e:
     raise ImportError(
         "Error: pyannote.core or faster_whisper types not found. "

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -357,11 +357,11 @@ if __name__ == "__main__":
         # Ensure logger is setup for test runs if not already done globally
         try:
             # Minimal setup if global setup didn't happen
-            if not logging.getLogger('RealEstateTranscriber').hasHandlers():
+            if not logging.getLogger('TranscriberApp').hasHandlers():
                 setup_logging(level=logging.DEBUG)
                 print("Test-specific logger setup complete (DEBUG level).")
             else:
-                 print(f"Logger already configured. Current level: {logging.getLevelName(logging.getLogger('RealEstateTranscriber').level)}")
+                 print(f"Logger already configured. Current level: {logging.getLevelName(logging.getLogger('TranscriberApp').level)}")
         except Exception as log_setup_err:
             print(f"Error setting up logging for test: {log_setup_err}")
 

--- a/src/utils/log.py
+++ b/src/utils/log.py
@@ -44,7 +44,7 @@ class IconFormatter(logging.Formatter):
         return f"{timestamp} {icon} {message_part}"
 
 # --- Logger Setup ---
-app_logger = logging.getLogger('RealEstateTranscriber')
+app_logger = logging.getLogger('TranscriberApp')
 _handlers_configured = False
 
 def setup_logging(config_path: Path = DEFAULT_CONFIG_PATH, level: int = logging.INFO):
@@ -124,7 +124,7 @@ def log(message: str,
         message = f"[{job_id}] {message}"
 
     level_upper = level.upper()
-    logger_instance = logging.getLogger('RealEstateTranscriber')
+    logger_instance = logging.getLogger('TranscriberApp')
 
     if level_upper == "DEBUG":
         logger_instance.debug(message)


### PR DESCRIPTION
## Summary
- clean up unused import in merge
- rename logger to `TranscriberApp`
- update references to new logger

## Testing
- `make check` *(fails: ruff found style errors in unrelated files)*
- `ruff check src/core/merge.py src/utils/log.py src/transcriber.py`

------
https://chatgpt.com/codex/tasks/task_e_683f42744ba0832c8a78c00e15efda2e