### PR TITLE
Clean up import-time prints

### DIFF
--- a/src/job_manager.py
+++ b/src/job_manager.py
@@ -1,6 +1,5 @@
 # src/job_manager.py
 # Begin van src/job_manager.py
-print("<<<<< LOADING src/job_manager.py - VERSION CHECK (DATUM/TIJD OF VERSIENUMMER) >>>>>")
 
 
 import uuid
@@ -19,6 +18,8 @@ from src.constants import (
     STATUS_COMPLETED, STATUS_FAILED, STATUS_STOPPED, STATUS_UNKNOWN,
     TERMINAL_STATUSES, STOPPABLE_STATUSES
 )
+
+log("Loaded src/job_manager.py", "DEBUG")
 
 
 class JobManager:

--- a/src/pipeline_part1.py
+++ b/src/pipeline_part1.py
@@ -1,32 +1,27 @@
 # src/pipeline_part1.py
-print("<<<<< LOADING src/pipeline_part1.py - VERSION CHECK (DATUM/TIJD OF VERSIENUMMER) >>>>>")
 
-import time
-import os
 import json
+import os
+import time
 import traceback
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from src.job_manager import job_manager, STATUS_RUNNING, STATUS_PROCESSING_AUDIO, \
-    STATUS_DETECTING_NAMES, STATUS_WAITING_FOR_REVIEW, \
-    STATUS_STOPPED, STATUS_FAILED
-from src.transcriber import transcribe_and_diarize, DEFAULT_WHISPER_MODEL, \
-     DEFAULT_COMPUTE_TYPE, DEFAULT_PYANNOTE_PIPELINE
-
-try:
-    from src.speaker_name_detector import detect_speaker_names
-    NAME_DETECTOR_AVAILABLE = True
-except ImportError:
-    print("[PipelinePart1 WARNING] Speaker name detector module (src.speaker_name_detector) not found, disabling automatic name detection.")
-    NAME_DETECTOR_AVAILABLE = False
-    # Aangepaste dummy voor consistentie met de verwachte return signature in deze flow
-    def detect_speaker_names(*args, **kwargs) -> Tuple[Dict[str, Any], Dict[int, str]]: # Oorspronkelijk Dict[str, Optional[str]]
-        # Als de "echte" detector een Dict[str, Dict[str, Any]] teruggeeft, zou de dummy dat ook moeten doen.
-        # Voor nu houden we het simpel, de verwerkingslogica in run_part1 probeert dit te accommoderen.
-        return {}, {}
-
-
+from src.job_manager import (
+    job_manager,
+    STATUS_RUNNING,
+    STATUS_PROCESSING_AUDIO,
+    STATUS_DETECTING_NAMES,
+    STATUS_WAITING_FOR_REVIEW,
+    STATUS_STOPPED,
+    STATUS_FAILED,
+)
+from src.transcriber import (
+    transcribe_and_diarize,
+    DEFAULT_WHISPER_MODEL,
+    DEFAULT_COMPUTE_TYPE,
+    DEFAULT_PYANNOTE_PIPELINE,
+)
 from src.utils.load_config import load_config
 from src.utils.config_schema import PROJECT_ROOT
 from src.utils.log import log
@@ -35,8 +30,23 @@ from src.constants import (
     PROGRESS_START as APP_PROGRESS_START,
     PROGRESS_AFTER_AUDIO_PROCESSING as APP_PROGRESS_AFTER_AUDIO_PROCESSING,
     PROGRESS_AFTER_NAME_DETECT as APP_PROGRESS_AFTER_NAME_DETECT,
-    PROGRESS_WAITING_REVIEW as APP_PROGRESS_WAITING_REVIEW
+    PROGRESS_WAITING_REVIEW as APP_PROGRESS_WAITING_REVIEW,
 )
+
+try:
+    from src.speaker_name_detector import detect_speaker_names
+    NAME_DETECTOR_AVAILABLE = True
+except ImportError:
+    log(
+        "[PipelinePart1 WARNING] Speaker name detector module (src.speaker_name_detector) not found, disabling automatic name detection.",
+        "WARNING",
+    )
+    NAME_DETECTOR_AVAILABLE = False
+
+    def detect_speaker_names(*args, **kwargs) -> Tuple[Dict[str, Any], Dict[int, str]]:
+        return {}, {}
+
+log("Loaded src/pipeline_part1.py", "DEBUG")
 
 # Gebruik de geimporteerde constantes met hun alias
 PROGRESS_START = APP_PROGRESS_START

--- a/src/pipeline_part2.py
+++ b/src/pipeline_part2.py
@@ -1,6 +1,5 @@
 # src/pipeline_part2.py
 # Begin van src/pipeline_part2.py
-print("<<<<< LOADING src/pipeline_part2.py - VERSION CHECK (DATUM/TIJD OF VERSIENUMMER) >>>>>")
 
 import time
 import os
@@ -39,6 +38,9 @@ from src.utils.pipeline_helpers import check_stop
 from src.utils.config_schema import PROJECT_ROOT
 from src.database_logger import log_job_to_db, get_db_path # get_db_path is niet gebruikt, maar kan blijven
 from src.utils.log import log
+
+# Log module load
+log("Loaded src/pipeline_part2.py", "DEBUG")
 
 # --- Define Folder Paths using constants ---
 RESULTS_DIR = PROJECT_ROOT / RESULTS_FOLDER_NAME

--- a/src/routes/review_routes.py
+++ b/src/routes/review_routes.py
@@ -5,7 +5,6 @@ van de Transcriber‑pipeline.
 """
 from __future__ import annotations # DEZE MOET HIER, ALS EERSTE IMPORT/CODE
 
-print("<<<<< LOADING src/routes/review_routes.py - VERSION (jouw versie hier) >>>>>") # DAARNA DE PRINT
 
 
 import json
@@ -19,6 +18,8 @@ from src.job_manager import STATUS_WAITING_FOR_REVIEW, job_manager
 from src.pipeline_part2 import run_part2
 from src.utils.config_schema import PROJECT_ROOT
 from src.utils.log import log
+
+log("Loaded src/routes/review_routes.py", "DEBUG")
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Blueprint


### PR DESCRIPTION
## Summary
- remove print statements executed at import time
- log module load events in pipeline, job manager, and review routes
- keep imports ordered to satisfy Ruff E402

## Testing
- `ruff check --select E402 src/pipeline_part1.py`
- `ruff check --select E402 src/pipeline_part2.py`
- `ruff check --select E402 src/job_manager.py`
- `ruff check --select E402 src/routes/review_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f426cf910832caffbeb24b3472604