### PR TITLE
Fix duplicate review submission call

### DIFF
--- a/frontend/src/lib/components/ReviewDialog.svelte
+++ b/frontend/src/lib/components/ReviewDialog.svelte
@@ -4,7 +4,6 @@
   import { apiBaseUrl } from '../stores.js';
   import {
     getReviewData as apiGetReviewData,
-    updateReviewData as apiUpdateReviewData,
     updateTranscriptData
   } from '../api.js';
 
@@ -123,8 +122,7 @@
         console.log('[ReviewDialog] Transcript is being edited, saving transcript first...');
         await saveTranscriptEdits();
       }
-      console.log('[ReviewDialog] Submitting final speaker map:', editedMap);
-      await apiUpdateReviewData(jobId, editedMap);
+      console.log('[ReviewDialog] Dispatching final speaker map to parent:', editedMap);
       dispatch('submit', editedMap);
     } catch (e) {
       console.error('[ReviewDialog] saveAll operation failed:', e);


### PR DESCRIPTION
## Summary
- prevent ReviewDialog from submitting review data directly
- dispatch final speaker map to JobRunner which sends the API request

## Testing
- `make lint` *(fails: Found 111 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843eb145a18832c82fd56bb5f331e93