### PR TITLE
Add health endpoint and initialize popup visibility state

### DIFF
--- a/app.py
+++ b/app.py
@@ -258,6 +258,13 @@ def health_check():
     log("Health check '/' endpoint accessed.", "DEBUG")
     return jsonify({"status": "ok", "message": "Transcriber API is running."})
 
+@app.route("/healthz")
+@cross_origin(origins=cors_origins_list)
+def healthz():
+    """Lightweight endpoint used by the frontend to verify server health."""
+    log("Health check '/healthz' endpoint accessed.", "DEBUG")
+    return jsonify({"status": "ok"})
+
 # Endpoint voor losse TXT‑export - Deze is specifiek en lijkt buiten de hoofd API flow
 # De @cross_origin decorator hier is redundant als de globale CORS(app, ...) al alles dekt.
 # Echter, als je fijnmazige controle wilt per route, kan het nuttig zijn.

--- a/frontend/src/lib/components/ReviewDialog.svelte
+++ b/frontend/src/lib/components/ReviewDialog.svelte
@@ -23,6 +23,7 @@
   let uniqueSpeakers = [];
   let editedMap = {};
   let contextVisible = {};
+  let whyVisible = {};
   let rolesHint = {};
   let firstSpeakerId = null;
 
@@ -58,12 +59,15 @@
 
       const initialEditedMap = {};
       const initialContextVisible = {};
+      const initialWhyVisible = {};
       uniqueSpeakers.forEach((id) => {
         initialEditedMap[id] = proposedMap[id]?.name ?? '';
         initialContextVisible[id] = false;
+        initialWhyVisible[id] = false;
       });
       editedMap = initialEditedMap;
       contextVisible = initialContextVisible;
+      whyVisible = initialWhyVisible;
 
     } catch (e) {
       console.error('[ReviewDialog] Fetch review data failed:', e);


### PR DESCRIPTION
## Summary
- add `/healthz` endpoint for frontend health check
- initialize `whyVisible` map so speaker reasoning toggle works

## Testing
- `python3 -m ruff check app.py` *(fails: module-level import ordering errors)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b28e882034832ca3ec69e96536f9b6