### PR TITLE
Add health endpoint and avoid stale summary data

### DIFF
--- a/app.py
+++ b/app.py
@@ -258,6 +258,13 @@ def health_check():
     log("Health check '/' endpoint accessed.", "DEBUG")
     return jsonify({"status": "ok", "message": "Transcriber API is running."})
 
+@app.route("/healthz")
+@cross_origin(origins=cors_origins_list)
+def healthz():
+    """Lightweight endpoint used by the frontend to verify server health."""
+    log("Health check '/healthz' endpoint accessed.", "DEBUG")
+    return jsonify({"status": "ok"})
+
 # Endpoint voor losse TXT‑export - Deze is specifiek en lijkt buiten de hoofd API flow
 # De @cross_origin decorator hier is redundant als de globale CORS(app, ...) al alles dekt.
 # Echter, als je fijnmazige controle wilt per route, kan het nuttig zijn.

--- a/frontend/src/lib/components/JobRunner.svelte
+++ b/frontend/src/lib/components/JobRunner.svelte
@@ -71,6 +71,8 @@
     }
   }
 
+  $: cacheSuffix = $currentJob.job_id ? `?v=${$currentJob.job_id}` : '';
+
   async function startPipelineAction() {
     if (!canStart) return;
     log('Attempting to start pipeline with:', {
@@ -310,12 +312,12 @@
 
   {#if $currentJob.status === 'COMPLETED'}
     <ResultViewer
-      htmlPath="results/transcript.html"
-      summaryPath="results/summary.txt"
-      advancedPath="results/advanced_analysis.json"
+      htmlPath={$currentJob.result?.transcript_path ? `${$currentJob.result.transcript_path}${cacheSuffix}` : undefined}
+      summaryPath={$currentJob.result?.summary_path ? `${$currentJob.result.summary_path}${cacheSuffix}` : undefined}
+      advancedPath={$currentJob.result?.advanced_analysis_path ? `${$currentJob.result.advanced_analysis_path}${cacheSuffix}` : undefined}
       jobId={$currentJob.job_id}
       audioRelativePath={$currentJob.relative_audio_path}
-      on:rerun={() => { 
+      on:rerun={() => {
         // Reset local UI state and resume polling for re-analysis
         if (pollInterval) stopPolling();
         currentJob.patch({ status: 'ANALYZING', progress: 0 });

--- a/frontend/src/lib/components/ResultViewer.svelte
+++ b/frontend/src/lib/components/ResultViewer.svelte
@@ -32,22 +32,28 @@
 
   async function loadResources() {
     if (htmlPath) {
-      try { transcriptHtml = await (await fetch(htmlPath)).text(); }
+      try { transcriptHtml = await (await fetch(htmlPath, { cache: 'no-store' })).text(); }
       catch (err) { transcriptHtml = `<p class=\"text-red-600\">Kon transcript niet laden: ${err.message}</p>`; }
     }
     if (summaryPath) {
-      try { summaryText = await (await fetch(summaryPath)).text(); }
+      try { summaryText = await (await fetch(summaryPath, { cache: 'no-store' })).text(); }
       catch (err) { summaryText = `Kon samenvatting niet laden: ${err.message}`; }
     }
     if (advancedPath) {
       try {
-        const res = await fetch(advancedPath);
+        const res = await fetch(advancedPath, { cache: 'no-store' });
         if (res.ok) advanced = await res.json();
       } catch (err) { /* optional */ }
     }
   }
 
   onMount(loadResources);
+
+  let prevPaths = { htmlPath, summaryPath, advancedPath };
+  $: if (htmlPath !== prevPaths.htmlPath || summaryPath !== prevPaths.summaryPath || advancedPath !== prevPaths.advancedPath) {
+    prevPaths = { htmlPath, summaryPath, advancedPath };
+    loadResources();
+  }
 
   // Build/refresh the local cache of word spans when HTML changes
   function buildWordIndex() {

--- a/frontend/src/lib/components/ReviewDialog.svelte
+++ b/frontend/src/lib/components/ReviewDialog.svelte
@@ -23,6 +23,7 @@
   let uniqueSpeakers = [];
   let editedMap = {};
   let contextVisible = {};
+  let whyVisible = {};
   let rolesHint = {};
   let firstSpeakerId = null;
 
@@ -58,12 +59,22 @@
 
       const initialEditedMap = {};
       const initialContextVisible = {};
+      const initialWhyVisible = {};
       uniqueSpeakers.forEach((id) => {
         initialEditedMap[id] = proposedMap[id]?.name ?? '';
         initialContextVisible[id] = false;
+        initialWhyVisible[id] = false;
+      });
+
+      // Fallback: if no LLM suggestion, try extracting names from greetings
+      greetingMatches().forEach(({ speaker, name }) => {
+        if (!initialEditedMap[speaker]) {
+          initialEditedMap[speaker] = name;
+        }
       });
       editedMap = initialEditedMap;
       contextVisible = initialContextVisible;
+      whyVisible = initialWhyVisible;
 
     } catch (e) {
       console.error('[ReviewDialog] Fetch review data failed:', e);
@@ -369,7 +380,7 @@
                       on:click={() => toggleContext(speakerId)}
                       class="px-3 py-1.5 bg-gray-700 rounded text-sm hover:bg-gray-600 transition-colors text-gray-200 w-full sm:w-auto"
                     >
-                      {#if contextVisible[speakerId]}Verberg{:else}Waarom?{/if}
+                      {#if contextVisible[speakerId]}Verberg context{:else}Toon context{/if}
                     </button>
                   {/if}
                 </div>

--- a/frontend/src/lib/components/ReviewDialog.svelte
+++ b/frontend/src/lib/components/ReviewDialog.svelte
@@ -24,6 +24,7 @@
   let editedMap = {};
   let contextVisible = {};
   let whyVisible = {};
+  let greetingCache = [];
   let rolesHint = {};
   let firstSpeakerId = null;
 
@@ -67,7 +68,8 @@
       });
 
       // Fallback: if no LLM suggestion, try extracting names from greetings
-      greetingMatches().forEach(({ speaker, name }) => {
+      greetingCache = greetingMatches();
+      greetingCache.forEach(({ speaker, name }) => {
         if (!initialEditedMap[speaker]) {
           initialEditedMap[speaker] = name;
         }
@@ -147,9 +149,8 @@
     if (rolesHint?.callee) lines.push(`Context: callee = ${rolesHint.callee}`);
     const role = roleForSpeaker(sid);
     if (role) lines.push(`Rol-hint: deze spreker is '${role}'.`);
-    const gm = greetingMatches();
-    if (gm.length){
-      const relevant = gm.map(g=>`[Index ${g.index}] ${g.speaker} begroet '${g.name}' → toegewezen aan andere spreker`).join('\n');
+    if (greetingCache.length){
+      const relevant = greetingCache.map(g=>`[Index ${g.index}] ${g.speaker} begroet '${g.name}' → toegewezen aan andere spreker`).join('\n');
       lines.push('Begroetingspatronen:\n'+relevant);
     }
     const ri = proposedMap[sid]?.reasoning_indices || [];
@@ -195,6 +196,7 @@
       }
       await updateTranscriptData(jobId, updatedFullTranscript);
       transcript = updatedFullTranscript;
+      greetingCache = greetingMatches();
       isEditingTranscript = false;
       // If early segments changed, re-run name detection to refresh suggestions
       if (firstNChanged) {


### PR DESCRIPTION
## Summary
- add `/healthz` endpoint for frontend health check
- initialize `whyVisible` map so speaker reasoning toggle works
- load result files using job-specific paths to prevent cached summaries
- prefill speaker names from greeting lines when LLM suggestions are missing
- refresh result viewer resources whenever result paths change
- rename context toggle to avoid duplicate "Waarom?" buttons for speakers

## Testing
- `python3 -m ruff check app.py` *(fails: module import order errors)*
- `npm run lint` *(fails: missing `lint` script)*

------
https://chatgpt.com/codex/tasks/task_e_68b28e882034832ca3ec69e96536f9b6